### PR TITLE
Improving CallbackSubscriber to handle with bounces / complaints in a Notification type

### DIFF
--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -130,10 +130,10 @@ class CallbackSubscriber implements EventSubscriberInterface
      * @see https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-examples.html#event-publishing-retrieving-sns-bounce
      *
      * @param string $type
-     * @param string $message
+     * @param $message
      * @return void
      */
-    public function processJsonPayload(string $type, string $message = ''): void
+    public function processJsonPayload(string $type, $message = ''): void
     {
         switch ($type) {
             case 'SubscriptionConfirmation':


### PR DESCRIPTION
This pull request improves the processJsonPayload, processBounce, and processComplaint methods.

During my tests I realized the payload that come directly from AWS can be a Bounce or a Complaint but inside a 'Type' : 'Notification' instead of an event. 

This can be noticed if trying to 'Send test email' on the AWS console. These emails ( by default ) are defined as 'Type' : 'Notification'  ( if no configuration set is defined ).

This improve don't change the normal behavior of the rest of event data ( only affects the 'Notification' ) and the idea came from some plugins that do the same recursive instruction, like this one: [https://github.com/pm-pmaas/etailors_amazon_ses/blob/main/EventSubscriber/CallbackSubscriber.php](https://github.com/pm-pmaas/etailors_amazon_ses/blob/main/EventSubscriber/CallbackSubscriber.php)

The example of the payload I'm talking about is on the issue nº 5 opened by me [here](https://github.com/pabloveintimilla/mautic-amazon-ses/issues/5)

**### Changes done:**

**processJsonPayload Method:**

- Added a dedicated checkNotificationType method to handle recursive processing of Bounce and Complaint case a 'Notification' type instead of an event type.

**checkNotificationType Method:**

- Introduced a new method to decode and validate notification types (Bounce and Complaint) from the Message field.

- Added recursive call to processJsonPayload if the notification type one of those.

**processBounce Method:**

- Updated to use the provided message or default to $this->payload.

**processComplaint Method:**

- Updated to use the provided message or default to $this->payload.

These changes aim to streamline the processing logic for non eventType and feel free to adjust the code or not accept this at all if this don't make sense.

Cheers!
